### PR TITLE
Add discovery, registration, and session-auth tools to the MCP proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,9 @@ API_HTTP_TIMEOUT=60
 # Host/port this MCP server (streamable-http) binds to.
 MCP_HOST=0.0.0.0
 MCP_PORT=8000
+
+# JWT for testing. NOT used by the server/container itself — the MCP client
+# (e.g. Claude Code via .mcp.json) forwards it as the Authorization header.
+# Export it in the shell where you launch the client:  export FLEXREPORT_JWT=...
+# Obtain one from the backend's POST /token (OAuth2 password flow).
+FLEXREPORT_JWT=

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@ __pycache__/
 .venv/
 venv/
 .DS_Store
+
+# MCP client config — may contain a bearer JWT
+.mcp.json
+
+# Generated report artifacts
+reports/

--- a/README.md
+++ b/README.md
@@ -18,8 +18,20 @@ API repo; the only contract is the HTTP API + a JWT.
 | `generate_research_report(query, delivery)` | `POST /generate-research-report` | Start a report job from a plain-English query → `{task_id, status}` |
 | `get_task_status(task_id)` | `GET /task-status` | Poll an async job to `SUCCESS` and read its `result` |
 | `get_report_artifact(symbols)` | `POST /get-cached-reports` | Bulk-fetch cached PDFs (base64) + a `missing` list |
+| `list_report_options(kind)` | `GET /list-realtime-event-options`, `/list-financial-items`, `/list-financial-ratios`, `/get-sectors`, `/list-institutional-investor-types`, `/list-countries`, `/get-fiscal-quarter` | Enumerate valid values for a parameter (event types, ratios, sectors, investor types, countries, fiscal quarter) |
+| `list_sub_industries(sectors)` | `GET /get-sub-industries` | Distinct industries within the given sector(s) |
+| `list_tickers(with_names)` | `GET /list-tickers` or `/list-symbols-with-names` | The covered ticker universe (optionally with company names) |
+| `get_company_snapshot(symbol)` | `GET /get-company-snapshot` | Structured snapshot: thesis, fundamentals, technicals, price targets, ownership, grades |
+| `onboard_symbol(symbol)` | `POST /onboard-symbol` | Request onboarding of an uncovered ticker (async, authed, 5/hour) |
+| `register_user(email, password)` | `POST /auth` | Register for an API key; backend emails a confirmation token (pre-auth) |
+| `confirm_registration(token)` | `GET /confirm/{token}` | Confirm a registration with the emailed token (pre-auth) |
+| `get_token(username, password)` | `POST /token` | Exchange credentials for a bearer JWT (OAuth2 password flow, pre-auth) |
+| `login(username, password)` | `POST /token` | Authenticate and **cache** the JWT for this session — auto-applied to later calls (pre-auth) |
+| `logout()` | — | Clear the session's cached JWT |
 
-Typical agent loop: **discover** events → **generate** a report → **poll** status → **fetch** artifact.
+Typical agent loop: **discover** valid params (`list_report_options`) → **discover** events → **generate** a report → **poll** status → **fetch** artifact.
+
+Auth resolution per call: explicit `bearer_token` arg → the session's cached JWT (from `login`) → the inbound `Authorization` header.
 
 ## Run locally
 
@@ -33,10 +45,30 @@ python server.py              # serves streamable-http on http://MCP_HOST:MCP_PO
 
 ## Auth
 
-1. Get a JWT once from the backend: `POST /token` (OAuth2 password flow).
-2. Configure it in your MCP client as the `Authorization: Bearer <JWT>` header.
-3. The agent's calls carry that header → this server forwards it → the backend
-   authenticates and meters the request as that user.
+Three ways to authenticate, all backed by the backend's `POST /token` (OAuth2
+password flow). Pick one — no Authorization header is required in `.mcp.json`
+unless you choose the static option.
+
+**A. `login` tool (recommended — agent-driven, no config):**
+- *New user:* `register_user(email, password)` → `confirm_registration(token)` →
+  `login(email, password)`.
+- *Existing user:* `login(email, password)`.
+- The JWT is cached **per MCP session** (keyed by the `Mcp-Session-Id` header) and
+  auto-applied to every subsequent authed call — no `bearer_token`, no header in
+  `.mcp.json`. Concurrent sessions are isolated. Call `logout` to clear it; the
+  cache is in-memory and lost on restart. A backend 401 evicts it automatically.
+
+**B. `bearer_token` arg (explicit, per-call):**
+- `get_token(email, password)` → pass the returned `access_token` as the
+  `bearer_token` arg to `generate_report` / `get_report_artifact` / etc. Overrides
+  both the cache and the header.
+
+**C. Static header (single user):**
+- Configure `Authorization: Bearer <JWT>` in your MCP client; the server forwards
+  it on every call. Simplest, but the manual injection the other two avoid.
+
+This service still holds no credentials at rest — JWTs are forwarded per-call,
+never stored.
 
 ## Wire into an MCP client
 

--- a/client.py
+++ b/client.py
@@ -27,20 +27,61 @@ class MissingAuthError(Exception):
     """Raised when a JWT-protected tool is called without an inbound bearer token."""
 
 
-def auth_headers(request, *, required: bool = True) -> dict:
-    """Extract the inbound Authorization header to forward to the backend.
+# In-memory, per-session JWT cache (session key -> access token). Populated by the
+# `login` tool, consulted by auth_headers, cleared by `logout` / on a 401. Never
+# persisted — the service still holds no credentials at rest, and the cache is
+# lost on restart.
+_session_tokens: dict[str, str] = {}
 
-    `request` is the Starlette Request from `ctx.request_context.request` (or None
-    if unavailable). When `required` is True and no token is present, raises
-    MissingAuthError; when False, returns an empty dict (header simply omitted).
+
+def cache_token(session_key: str, token: str) -> None:
+    """Store a JWT for a session (called by the `login` tool)."""
+    _session_tokens[session_key] = token
+
+
+def clear_token(session_key: str) -> None:
+    """Drop a session's cached JWT (called by `logout` / on a 401)."""
+    _session_tokens.pop(session_key, None)
+
+
+def _bearer(value: str) -> str:
+    """Normalize a raw JWT (or pre-prefixed value) to a `Bearer <jwt>` header value."""
+    return value if value.lower().startswith("bearer ") else f"Bearer {value}"
+
+
+def auth_headers(
+    request,
+    *,
+    required: bool = True,
+    token: str | None = None,
+    session_key: str | None = None,
+) -> dict:
+    """Build the Authorization header to forward to the backend.
+
+    Resolution order:
+      1. An explicit `token` (threaded through a tool's `bearer_token` arg).
+      2. The session's cached JWT (set by the `login` tool), keyed by `session_key`.
+      3. The inbound `Authorization` header from `request` (the Starlette Request
+         from `ctx.request_context.request`, or None if unavailable).
+
+    When none are present and `required` is True, raises MissingAuthError; when
+    False, returns an empty dict (header simply omitted). All values normalized to
+    `Bearer <jwt>`.
     """
-    token = request.headers.get("authorization") if request is not None else None
-    if not token:
+    if token:
+        return {"Authorization": _bearer(token)}
+
+    cached = _session_tokens.get(session_key) if session_key else None
+    if cached:
+        return {"Authorization": _bearer(cached)}
+
+    inbound = request.headers.get("authorization") if request is not None else None
+    if not inbound:
         if required:
             raise MissingAuthError(
-                "No Authorization header found. Configure your MCP client with "
-                "'Authorization: Bearer <JWT>' — obtain a JWT from the backend's "
-                "POST /token (OAuth2 password flow)."
+                "Not authenticated. Call the `login` tool (or pass `bearer_token` "
+                "from `get_token`), or configure your MCP client with "
+                "'Authorization: Bearer <JWT>'."
             )
         return {}
-    return {"Authorization": token}
+    return {"Authorization": inbound}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  flexreport-mcp:
+    build: .
+    image: flexreport-mcp
+    container_name: flexreport-mcp
+    ports:
+      # host:container — keep host port aligned with .mcp.json (http://localhost:8000/mcp)
+      - "${MCP_PORT:-8000}:8000"
+    environment:
+      # Backend the proxy calls. Defaults to prod; override for local backend.
+      API_BASE_URL: "${API_BASE_URL:-https://flexreportfinapi.com}"
+      API_HTTP_TIMEOUT: "${API_HTTP_TIMEOUT:-60}"
+      MCP_HOST: "0.0.0.0"
+      MCP_PORT: "8000"
+    restart: unless-stopped

--- a/server.py
+++ b/server.py
@@ -8,12 +8,18 @@ AWS/Redis/DB or import anything from the API repo.
 """
 
 import os
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 import httpx
 from mcp.server.fastmcp import Context, FastMCP
 
-from client import MissingAuthError, auth_headers, get_client
+from client import (
+    MissingAuthError,
+    auth_headers,
+    cache_token,
+    clear_token,
+    get_client,
+)
 
 mcp = FastMCP(
     "flexreport",
@@ -27,21 +33,45 @@ def _inbound_request(ctx: Context):
     return getattr(ctx.request_context, "request", None)
 
 
+def _session_key(ctx: Context) -> str:
+    """Stable per-connection key for the session token cache.
+
+    Prefers the canonical streamable-http `Mcp-Session-Id` header (present on every
+    request after `initialize`); falls back to the ServerSession object identity
+    when the header is absent (e.g. stateless mode).
+    """
+    req = _inbound_request(ctx)
+    sid = req.headers.get("mcp-session-id") if req is not None else None
+    return sid or f"obj:{id(ctx.session)}"
+
+
 async def _send(
     ctx: Context,
     method: str,
     path: str,
     *,
     require_auth: bool = True,
+    bearer_token: Optional[str] = None,
     **kwargs: Any,
 ) -> Any:
     """Forward a request to the backend, returning parsed JSON or a structured error.
 
+    Auth resolution (handled by auth_headers): explicit `bearer_token` → the
+    session's cached JWT (set by `login`) → the inbound Authorization header. A
+    401 from the backend evicts the session's cached token so a stale JWT can't
+    wedge the session.
+
     Errors (missing auth, transport failure, non-2xx) are returned as a dict with
     an "error" key rather than raised, so the agent receives a clean, readable message.
     """
+    session_key = _session_key(ctx)
     try:
-        headers = auth_headers(_inbound_request(ctx), required=require_auth)
+        headers = auth_headers(
+            _inbound_request(ctx),
+            required=require_auth,
+            token=bearer_token,
+            session_key=session_key,
+        )
     except MissingAuthError as e:
         return {"error": str(e)}
 
@@ -55,7 +85,11 @@ async def _send(
             detail = resp.json()
         except Exception:
             detail = resp.text
-        return {"error": f"Backend returned HTTP {resp.status_code}", "detail": detail}
+        msg = f"Backend returned HTTP {resp.status_code}"
+        if resp.status_code == 401:
+            clear_token(session_key)
+            msg += " — session token cleared; call `login` again."
+        return {"error": msg, "detail": detail}
 
     try:
         return resp.json()
@@ -75,9 +109,10 @@ async def list_realtime_events(
     """Pull live earnings/market events from the backend's Redis-backed cache (12h TTL).
 
     `event_type` defaults to "eps_update". Other values include: eps_release,
-    8k_release, earnings_transcript_update, analyst_rating_update, news_evolution,
-    earnings_themes, llm_basket_update, strategy_update. The backend's
-    GET /list-realtime-event-options enumerates the authoritative set.
+    8k_release, company_update, biggest_mover, earnings_transcript_update,
+    analyst_rating_update, news_evolution, earnings_themes, llm_basket_update,
+    strategy_update. Call `list_report_options("event_types")` for the
+    authoritative, current set — do not guess.
 
     Optionally narrow results by `tickers`, `sector`, `industry`, or `market_cap`
     (e.g. market_cap=["Large-cap","Mega-cap"]). Returns a list of event objects,
@@ -100,19 +135,28 @@ async def generate_report(
     ctx: Context,
     ticker: str,
     overrides: Optional[dict] = None,
+    bearer_token: Optional[str] = None,
 ) -> Any:
     """Kick off generation of a full structured research report for one ticker.
 
     Only `ticker` is required; the backend applies sensible defaults for everything
     else. Pass `overrides` to customize the report (e.g.
     {"include_transcript": false, "ratios": [...], "filing_frequency": "annual"}).
+    Discover valid override values with `list_report_options`: "financial_items"
+    and "financial_ratios" for the line items/ratios, and
+    "institutional_investor_types" for `overrides.institutional_ownership`.
+
+    `bearer_token` (a JWT from `get_token`) authenticates as that user; omit it to
+    use the MCP client's configured Authorization header.
 
     This is asynchronous. The response is keyed by ticker, e.g.
     {"AAPL": {"task_id": "...", "status": "PENDING"}}. Read result["AAPL"]["task_id"]
     and poll it with `get_task_status` until status is SUCCESS.
     """
     payload = {"ticker": ticker, **(overrides or {})}
-    return await _send(ctx, "POST", "/create-full-report", json=payload)
+    return await _send(
+        ctx, "POST", "/create-full-report", json=payload, bearer_token=bearer_token
+    )
 
 
 @mcp.tool()
@@ -120,18 +164,21 @@ async def generate_research_report(
     ctx: Context,
     query: str,
     delivery: str = "email",
+    bearer_token: Optional[str] = None,
 ) -> Any:
     """Generate a research report from a plain-English query (extensible, multi-section).
 
     `query` is natural language, e.g. "high-growth semis with rising estimates".
     `delivery` defaults to "email". Rate-limited to 20/hour per user server-side.
+    `bearer_token` (a JWT from `get_token`) authenticates as that user; omit it to
+    use the MCP client's configured Authorization header.
 
     Asynchronous: returns {"task_id": "...", "status": "PENDING"}. Poll with
     `get_task_status` until SUCCESS, then read its `result`.
     """
     return await _send(
         ctx, "POST", "/generate-research-report",
-        json={"query": query, "delivery": delivery},
+        json={"query": query, "delivery": delivery}, bearer_token=bearer_token,
     )
 
 
@@ -149,14 +196,221 @@ async def get_task_status(ctx: Context, task_id: str) -> Any:
 
 
 @mcp.tool()
-async def get_report_artifact(ctx: Context, symbols: list[str]) -> Any:
+async def get_report_artifact(
+    ctx: Context,
+    symbols: list[str],
+    bearer_token: Optional[str] = None,
+) -> Any:
     """Bulk-fetch cached default PDF reports for a list of ticker symbols.
 
     Returns {"result": [{"symbol": "AAPL", "report": "<base64 pdf>"}, ...],
     "missing": ["XYZ", ...]} — `missing` lists symbols with no cached report.
     Symbols are normalized (uppercased, de-duplicated) by the backend.
+    `bearer_token` (a JWT from `get_token`) authenticates as that user; omit it to
+    use the MCP client's configured Authorization header.
     """
-    return await _send(ctx, "POST", "/get-cached-reports", json=symbols)
+    return await _send(
+        ctx, "POST", "/get-cached-reports", json=symbols, bearer_token=bearer_token
+    )
+
+
+# --- Discovery / metadata tools -------------------------------------------
+# Let the agent enumerate valid parameter values (event types, report override
+# items, sector/industry filters) instead of guessing. All read-only and public.
+
+_OPTION_ENDPOINTS = {
+    "event_types": "/list-realtime-event-options",
+    "financial_items": "/list-financial-items",
+    "financial_ratios": "/list-financial-ratios",
+    "sectors": "/get-sectors",
+    "institutional_investor_types": "/list-institutional-investor-types",
+    "countries": "/list-countries",
+    "fiscal_quarter": "/get-fiscal-quarter",
+}
+
+
+@mcp.tool()
+async def list_report_options(
+    ctx: Context,
+    kind: Literal[
+        "event_types",
+        "financial_items",
+        "financial_ratios",
+        "sectors",
+        "institutional_investor_types",
+        "countries",
+        "fiscal_quarter",
+    ],
+) -> Any:
+    """Enumerate the valid values for a parameter, straight from the backend.
+
+    Call this BEFORE guessing a parameter value. `kind` selects which catalog:
+
+    - "event_types"                  -> valid `event_type` for `list_realtime_events`
+                                        (eps_update, company_update, biggest_mover, ...)
+    - "financial_items"              -> line items usable in a report's `overrides`
+    - "financial_ratios"             -> ratios usable in `overrides.ratios`
+    - "sectors"                      -> valid `sector` filter values
+    - "institutional_investor_types" -> valid `overrides.institutional_ownership`
+                                        values for `generate_report`
+    - "countries"                    -> covered countries
+    - "fiscal_quarter"               -> the most recent fiscal quarter being reported
+
+    Authoritative and never stale: it reads the backend's live config, not a
+    hardcoded list.
+    """
+    return await _send(ctx, "GET", _OPTION_ENDPOINTS[kind], require_auth=False)
+
+
+@mcp.tool()
+async def list_sub_industries(ctx: Context, sectors: list[str]) -> Any:
+    """List the sub-industries within one or more sectors.
+
+    `sectors` must be values from `list_report_options("sectors")`. Returns the
+    distinct industries used to narrow `list_realtime_events(industry=[...])`.
+    """
+    return await _send(
+        ctx, "GET", "/get-sub-industries",
+        params={"sector": sectors}, require_auth=False,
+    )
+
+
+@mcp.tool()
+async def list_tickers(ctx: Context, with_names: bool = False) -> Any:
+    """List the ticker universe FlexReport covers.
+
+    `with_names=False` returns bare symbols; `with_names=True` returns
+    {symbol, company_name} pairs. NOTE: this is the full universe (thousands of
+    names) and can be a large payload.
+    """
+    path = "/list-symbols-with-names" if with_names else "/list-tickers"
+    return await _send(ctx, "GET", path, require_auth=False)
+
+
+@mcp.tool()
+async def get_company_snapshot(ctx: Context, symbol: str) -> Any:
+    """Fetch a structured company snapshot — no report generation needed.
+
+    Returns thesis/bull/bear, financial overview (Piotroski, valuation signal),
+    price performance + technical indicators, price targets, institutional
+    ownership, and analyst grades for `symbol`. Synchronous and cheap — prefer
+    this for a quick read instead of generating a full PDF report.
+    """
+    return await _send(
+        ctx, "GET", "/get-company-snapshot",
+        params={"symbol": symbol}, require_auth=False,
+    )
+
+
+@mcp.tool()
+async def onboard_symbol(
+    ctx: Context,
+    symbol: str,
+    bearer_token: Optional[str] = None,
+) -> Any:
+    """Request onboarding of a NOT-yet-covered ticker (mutating, authenticated).
+
+    Kicks off a 30-60 min backend workflow and emails the authenticated user when
+    the first report is ready. Rate-limited to 5/hour per user. Use only when a
+    symbol is missing from `list_tickers` / returns no data elsewhere.
+    `bearer_token` (a JWT from `get_token`) authenticates as that user; omit it to
+    use the MCP client's configured Authorization header.
+
+    Returns {"task_id": ..., "status": "PENDING"}.
+    """
+    return await _send(
+        ctx, "POST", "/onboard-symbol",
+        params={"symbol": symbol}, bearer_token=bearer_token,
+    )
+
+
+# --- Auth / registration --------------------------------------------------
+# Pre-auth flows (the user has no JWT yet, so these forward NO bearer token).
+#
+#   New user:      register_user(email, password)   -> backend emails a token
+#                  confirm_registration(token)       -> activates the account
+#                  login(email, password)            -> authenticated (seamless)
+#   Existing user: login(email, password)            -> authenticated (seamless)
+#
+# `login` caches the JWT for the current MCP session, so every subsequent authed
+# tool just works — no `bearer_token` threading and no Authorization header in the
+# MCP client config. `get_token` is the lower-level alternative: it returns the
+# raw JWT to pass as `bearer_token` or to configure as a static header.
+
+@mcp.tool()
+async def register_user(ctx: Context, email: str, password: str) -> Any:
+    """Register for a FlexReport Finance API key (step 1 of the auth flow).
+
+    Pre-auth — no JWT required. On success the backend emails a confirmation
+    token; pass that token to `confirm_registration` to activate the account.
+    Then obtain a JWT to authenticate the other tools.
+
+    Note: `password` is sent as a tool argument, so it appears in call logs.
+    """
+    return await _send(
+        ctx, "POST", "/auth",
+        json={"email": email, "password": password}, require_auth=False,
+    )
+
+
+@mcp.tool()
+async def confirm_registration(ctx: Context, token: str) -> Any:
+    """Confirm a registration with the emailed token (step 2 of the auth flow).
+
+    Pre-auth — no JWT required. `token` is the value emailed by `register_user`.
+    """
+    return await _send(ctx, "GET", f"/confirm/{token}", require_auth=False)
+
+
+@mcp.tool()
+async def get_token(ctx: Context, username: str, password: str) -> Any:
+    """Exchange credentials for a bearer JWT (OAuth2 password flow). Pre-auth.
+
+    Entry point for BOTH flows: a new user calls this after `confirm_registration`;
+    an existing user calls it directly. `username` is the account email.
+
+    Returns {"access_token": "<jwt>", "token_type": "bearer"}. Pass the
+    `access_token` as the `bearer_token` argument to the authenticated tools
+    (generate_report, generate_research_report, get_report_artifact,
+    onboard_symbol) to act as this user — or set it as your MCP client's
+    Authorization header for all future sessions.
+
+    Note: `password` is sent as a tool argument, so it appears in call logs.
+    """
+    return await _send(
+        ctx, "POST", "/token",
+        data={"username": username, "password": password}, require_auth=False,
+    )
+
+
+@mcp.tool()
+async def login(ctx: Context, username: str, password: str) -> Any:
+    """Authenticate and cache the JWT for THIS session — the seamless auth path.
+
+    Same OAuth2 password flow as `get_token`, but the JWT is stored server-side
+    for the current MCP session and auto-applied to every subsequent authenticated
+    tool call. So after `login` you don't pass `bearer_token` and the MCP client
+    needs no Authorization header. `username` is the account email.
+
+    Returns {"status": "authenticated", "user": ...} on success. Call `logout` to
+    clear it; the cache is in-memory and lost on server restart. Note: `password`
+    is sent as a tool argument, so it appears in call logs.
+    """
+    resp = await _send(
+        ctx, "POST", "/token",
+        data={"username": username, "password": password}, require_auth=False,
+    )
+    if isinstance(resp, dict) and resp.get("access_token"):
+        cache_token(_session_key(ctx), resp["access_token"])
+        return {"status": "authenticated", "user": username}
+    return resp  # surface the backend error (e.g. bad credentials) as-is
+
+
+@mcp.tool()
+async def logout(ctx: Context) -> Any:
+    """Clear the JWT cached for this session by `login`."""
+    clear_token(_session_key(ctx))
+    return {"status": "logged_out"}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Expands the FlexReport MCP proxy from **5 tools to 15** and makes auth agent-driven, so no JWT needs to live in `.mcp.json`.

### Discovery / metadata
- `list_report_options(kind)` — one enum-typed tool over the backend's `/list-*` option endpoints (event types, financial items/ratios, sectors, investor types, countries, fiscal quarter). Fixes guessing params (the `financial_release` miss).
- `list_sub_industries`, `list_tickers`, `get_company_snapshot`

### Auth / registration
- `register_user` → `confirm_registration` → `get_token`
- `login`/`logout`: cache the JWT **per MCP session** (keyed by `Mcp-Session-Id`, object-identity fallback) and auto-apply to every authed call; sessions isolated; a 401 evicts the cached token
- `bearer_token` override arg on the authenticated tools (explicit wins)

`auth_headers` resolution order: explicit `bearer_token` → session cache → inbound `Authorization` header. Cache is in-memory only — the service still holds no credentials at rest.

### Docs / infra
- README tools table + rewritten Auth section (login / bearer_token / static header)
- Adds `docker-compose.yml`; gitignores `.mcp.json` (may hold a JWT) and generated `reports/`

## Testing
Exercised end-to-end against a local container: new-user `register_user` → email confirm → `login` → authed `list_realtime_events` / `get_company_snapshot` / `get_report_artifact`, all using only the session-cached token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
