### PR TITLE
Gitignore local deploy/ artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ __pycache__/
 venv/
 .DS_Store
 
+#deploy
+deploy/
+
 # MCP client config — may contain a bearer JWT
 .mcp.json
 


### PR DESCRIPTION
## Summary
Adds `deploy/` to `.gitignore` so local deployment artifacts (task defs, runbooks containing the AWS account id, cluster name, ALB/VPC wiring, and hostnames) are never tracked or pushed.

Rule-only change — reveals nothing sensitive itself; it just makes the local "keep deploy/ private" protection durable for anyone who clones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
