### PR TITLE
docs: add Quick Install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,19 @@ It's a thin, stateless proxy over the backend's public HTTP API: it holds no
 credentials and only forwards the caller's bearer JWT, so the entire contract with
 the backend is an HTTP API + a JWT.
 
+## Quick Install
+
+Add the connector to Claude Code
+
+```bash
+claude mcp add --transport http flexreport https://mcp.flexreportfinapi.com/mcp
+```
+
+Then start Claude and just ask (e.g. *"pull the biggest movers from flexreport"*).
+The agent handles login for you on the first data call — register or sign in when
+prompted; you never paste a token. Add `--scope user` to make it available in every
+directory. See [Auth](#auth) for details.
+
 ## Tools
 
 | Tool | Backend endpoint | What it does |


### PR DESCRIPTION
## Summary
Adds a **Quick Install** section to the README (right before Tools) so a new user can get started in one command:

```
claude mcp add --transport http flexreport https://mcp.flexreportfinapi.com/mcp
```

Notes that the agent handles login on the first data call (no token pasting), mentions `--scope user`, and links to the Auth section. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
