### PR TITLE
Rename get_report_artifact -> get_latest_report; make report routing …

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ directory. See [Auth](#auth) for details.
 | Tool | Backend endpoint | What it does |
 |---|---|---|
 | `list_realtime_events(event_type, tickers, sector, industry, market_cap)` | `POST /get-realtime-events` | Pull live events (EPS updates, transcripts, ratings, …) from the 12h cache |
-| `generate_report(ticker, overrides)` | `POST /create-full-report` | Start a structured report job for a ticker → `{ticker: {task_id, status}}` |
+| `get_latest_report(symbols)` | `POST /get-cached-reports` | **Default report tool** — get the latest pre-built cached report(s) (base64 PDF) for one or more tickers, instantly, + a `missing` list |
+| `generate_report(ticker, overrides)` | `POST /create-full-report` | Build a **bespoke** report on the fly (slow, async) — only when the user wants custom line items/ratios/overrides → `{ticker: {task_id, status}}` |
 | `generate_research_report(query, delivery)` | `POST /generate-research-report` | Start a report job from a plain-English query → `{task_id, status}` |
 | `get_task_status(task_id)` | `GET /task-status` | Poll an async job to `SUCCESS` and read its `result` |
-| `get_report_artifact(symbols)` | `POST /get-cached-reports` | Bulk-fetch cached PDFs (base64) + a `missing` list |
+| `get_stock_picks(strategy_name)` | `GET /get-stock-picks` | Latest LLM-selected stock picks for the current rebalance (optionally one strategy) |
 | `list_report_options(kind)` | `GET /list-realtime-event-options`, `/list-financial-items`, `/list-financial-ratios`, `/get-sectors`, `/list-institutional-investor-types`, `/list-countries`, `/get-fiscal-quarter` | Enumerate valid values for a parameter (event types, ratios, sectors, investor types, countries, fiscal quarter) |
 | `list_sub_industries(sectors)` | `GET /get-sub-industries` | Distinct industries within the given sector(s) |
 | `list_tickers(with_names)` | `GET /list-tickers` or `/list-symbols-with-names` | The covered ticker universe (optionally with company names) |
@@ -42,7 +43,7 @@ directory. See [Auth](#auth) for details.
 | `confirm_registration(token)` | `GET /confirm/{token}` | Confirm a registration with the emailed token (pre-auth) |
 | `get_token(username, password)` | `POST /token` | Exchange credentials for a bearer JWT (OAuth2 password flow, pre-auth) |
 
-Typical agent loop: **discover** valid params (`list_report_options`) → **discover** events → **generate** a report → **poll** status → **fetch** artifact.
+Typical agent loop: for a research request, just call `get_latest_report(symbols)` to fetch the cached report instantly. Only when the user wants a customized report: **generate** it (`generate_report`) → **poll** status (`get_task_status`).
 
 Auth resolution per call: explicit `bearer_token` arg → the inbound `Authorization` header.
 
@@ -101,9 +102,9 @@ npx @modelcontextprotocol/inspector
 # Connect to http://localhost:8000/mcp with header Authorization: Bearer <JWT>
 # Confirm 5 tools list, then exercise:
 #   list_realtime_events("eps_update")        -> events (or [])
-#   generate_report("AAPL")                   -> read ["AAPL"]["task_id"]
+#   get_latest_report(["AAPL"])               -> base64 (or missing)  [default report path]
+#   generate_report("AAPL", overrides={...})  -> read ["AAPL"]["task_id"]  [bespoke only]
 #   get_task_status(task_id)                  -> eventually SUCCESS
-#   get_report_artifact(["AAPL"])             -> base64 (or missing)
 # Negative: call any JWT tool with no token   -> clean {"error": ...}, no crash
 ```
 

--- a/server.py
+++ b/server.py
@@ -27,13 +27,20 @@ AUTHENTICATE before any data tool. The user needs a FlexReport account + a JWT:
   confirmation link/token — have the user click the link (or paste the token to
   confirm_registration); then call get_token.
 Pass the access_token as the `bearer_token` argument on every data tool
-(list_realtime_events, generate_report, generate_research_report,
-get_report_artifact, onboard_symbol). On HTTP 401 the token expired — call
+(list_realtime_events, get_latest_report, generate_report, generate_research_report,
+onboard_symbol). On HTTP 401 the token expired — call
 get_token again and retry. Do NOT ask the user to paste tokens into config files.
 
+REPORTS — pick the right tool:
+- DEFAULT for "the report / research / analysis / writeup for <ticker>": call
+  get_latest_report(symbols=[...]). It returns the pre-built cached report instantly.
+- ONLY when the user explicitly wants a CUSTOM report (specific line items, ratios,
+  filing frequency, overrides): call generate_report. It builds a new report on the
+  fly and is slow/async. Do NOT use it for an ordinary research request.
+
 NO AUTH NEEDED: list_report_options, list_tickers, list_sub_industries,
-get_company_snapshot, get_task_status. Use list_report_options(...) to discover
-valid parameter values instead of guessing.
+get_company_snapshot, get_stock_picks, get_task_status. Use list_report_options(...)
+to discover valid parameter values instead of guessing.
 """
 
 mcp = FastMCP(
@@ -145,12 +152,14 @@ async def generate_report(
     overrides: Optional[dict] = None,
     bearer_token: Optional[str] = None,
 ) -> Any:
-    """Generate a BESPOKE full structured research report for one ticker (slow, on-demand).
+    """Build a NEW BESPOKE report on the fly for one ticker (slow, async). NOT the default.
 
-    NOT the default path. Prefer `get_report_artifact` for an ordinary report request
-    — it returns the pre-built cached PDF instantly. Reach for THIS tool only when the
-    user wants something custom that the cached report can't satisfy: specific line
-    items, ratios, filing frequency, institutional-ownership cuts, or other `overrides`.
+    ===> DO NOT use this for an ordinary "get me the report / research / analysis"
+    request — use `get_latest_report` instead, which returns the pre-built cached
+    report instantly. This tool kicks off a slow, asynchronous build and should be
+    reached for ONLY when the user explicitly wants to CUSTOMIZE the report with
+    specific line items, ratios, filing frequency, institutional-ownership cuts, or
+    other `overrides` that the cached report does not already cover.
 
     Only `ticker` is required; the backend applies sensible defaults for everything
     else. Pass `overrides` to customize the report (e.g.
@@ -209,20 +218,28 @@ async def get_task_status(ctx: Context, task_id: str) -> Any:
 
 
 @mcp.tool()
-async def get_report_artifact(
+async def get_latest_report(
     ctx: Context,
     symbols: list[str],
     bearer_token: Optional[str] = None,
 ) -> Any:
-    """Bulk-fetch cached default PDF reports for a list of ticker symbols.
+    """Get the latest FlexReport research report(s) for one or more tickers. USE THIS BY DEFAULT.
 
-    THE DEFAULT path for any ordinary "get me a report / reports" request — it
-    returns pre-built reports instantly and cheaply. Use this unless the user clearly
-    wants a customized report (specific line items, ratios, filing frequency, etc.),
-    in which case use `generate_report`.
+    ===> THIS IS THE DEFAULT, CORRECT TOOL whenever a user asks for "the report",
+    "research", "the latest research", "analysis", "a writeup", or "the PDF" for a
+    ticker (e.g. "get me the latest research on SNOW"). It returns the pre-built,
+    cached report instantly — fast and cheap. ALWAYS prefer this over generating a
+    report on the fly.
 
-    Returns {"result": [{"symbol": "AAPL", "report": "<base64 pdf>"}, ...],
-    "missing": ["XYZ", ...]} — `missing` lists symbols with no cached report.
+    Do NOT use `generate_report` for an ordinary research request — that tool builds
+    a brand-new BESPOKE report on the fly (slow, async) and is ONLY for when the user
+    explicitly asks to CUSTOMIZE the report with specific line items, ratios, filing
+    frequency, or other overrides the cached report does not already cover.
+
+    Accepts one OR many symbols. Returns
+    {"result": [{"symbol": "AAPL", "report": "<base64 pdf>"}, ...],
+    "missing": ["XYZ", ...]} — `missing` lists symbols with no cached report (for
+    those, the user may want `generate_report` or `onboard_symbol`).
     Symbols are normalized (uppercased, de-duplicated) by the backend.
     `bearer_token` (a JWT from `get_token`) authenticates as that user; omit it to
     use the MCP client's configured Authorization header.
@@ -481,8 +498,8 @@ async def get_token(ctx: Context, username: str, password: str) -> Any:
 
     Returns {"access_token": "<jwt>", "token_type": "bearer"}. Pass the
     `access_token` as the `bearer_token` argument on every authenticated tool
-    (list_realtime_events, generate_report, generate_research_report,
-    get_report_artifact, onboard_symbol). Re-call this and retry on a 401.
+    (list_realtime_events, get_latest_report, generate_report,
+    generate_research_report, onboard_symbol). Re-call this and retry on a 401.
 
     Note: `password` is sent as a tool argument, so it appears in call logs.
     """


### PR DESCRIPTION
…explicit

Tool selection is driven mostly by the tool name and the connect-time INSTRUCTIONS block, not docstrings — so the prior docstring-only change didn't stop clients defaulting to building reports on the fly.

- Rename get_report_artifact -> get_latest_report (name now signals the default "get me the research" path)
- Add an explicit REPORTS routing rule to the INSTRUCTIONS block
- Make get_latest_report / generate_report docstrings emphatic about which is the default vs. the bespoke/custom path
- Refresh README table, agent-loop note, and Inspector example