### PR TITLE
Add OAuth 2.1 Resource Server support to the MCP server (AUTH_MODE)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,8 +10,23 @@ API_HTTP_TIMEOUT=60
 MCP_HOST=0.0.0.0
 MCP_PORT=8000
 
-# JWT for testing. NOT used by the server/container itself — the MCP client
-# (e.g. Claude Code via .mcp.json) forwards it as the Authorization header.
+# --- OAuth Resource-Server auth -------------------------------------------
+# AUTH_MODE selects how inbound requests are authenticated:
+#   legacy → no token validation; agent self-serves via get_token/register_user (default)
+#   both   → validate RS256 OAuth tokens via the backend JWKS; pass through non-OAuth
+#            tokens (legacy static-JWT users keep working); password tools removed
+#   oauth  → strict: only valid RS256 OAuth tokens accepted
+AUTH_MODE=legacy
+
+# Must match the backend OAuthProvider. The backend's OAUTH_AUDIENCE falls back to
+# OAUTH_ISSUER when unset, so OAUTH_AUDIENCE here mirrors that default.
+OAUTH_ISSUER=https://app.flexreportfinapi.com
+# OAUTH_AUDIENCE=https://mcp.flexreportfinapi.com/mcp   # set on BOTH sides for true audience binding
+# OAUTH_JWKS_URL=https://app.flexreportfinapi.com/.well-known/jwks.json   # defaults to {issuer}/.well-known/jwks.json
+# This server's canonical resource identifier (advertised in protected-resource metadata).
+MCP_RESOURCE_URL=https://mcp.flexreportfinapi.com/mcp
+
+# JWT for testing in AUTH_MODE=legacy only. NOT used by the server/container itself —
+# the MCP client (e.g. Claude Code via .mcp.json) forwards it as the Authorization header.
 # Export it in the shell where you launch the client:  export FLEXREPORT_JWT=...
-# Obtain one from the backend's POST /token (OAuth2 password flow).
 FLEXREPORT_JWT=

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY client.py server.py ./
+COPY client.py server.py auth_verifier.py ./
 
 # Streamable-http transport. Override via env at runtime.
 ENV MCP_HOST=0.0.0.0 \

--- a/auth_verifier.py
+++ b/auth_verifier.py
@@ -1,0 +1,91 @@
+"""OAuth Resource-Server token validation for the FlexReport MCP server.
+
+The MCP server is an OAuth 2.0 Resource Server: it validates the inbound bearer
+token (issued by the backend Authorization Server) and lets the MCP SDK serve the
+protected-resource metadata + 401 challenges. It never sees a password.
+
+Validation uses the backend's published JWKS (RS256 public key), so this service
+holds no signing secret — it stays a credential-free proxy.
+
+Config (env), aligned to the backend's `OAuthProvider`:
+  OAUTH_ISSUER      token `iss` + the advertised authorization server
+                    (backend default: https://app.flexreportfinapi.com)
+  OAUTH_AUDIENCE    expected token `aud`. The backend falls back to the issuer when
+                    its own OAUTH_AUDIENCE is unset, so we mirror that default.
+                    Set both sides to the canonical MCP URL for true audience binding.
+  OAUTH_JWKS_URL    where to fetch the public keys (default: {issuer}/.well-known/jwks.json)
+  MCP_RESOURCE_URL  this server's canonical resource identifier (the PRM `resource`)
+"""
+
+import os
+
+import anyio
+import jwt
+from jwt import PyJWKClient
+from mcp.server.auth.provider import AccessToken, TokenVerifier
+
+OAUTH_ISSUER = os.environ.get("OAUTH_ISSUER", "https://app.flexreportfinapi.com")
+OAUTH_AUDIENCE = os.environ.get("OAUTH_AUDIENCE", OAUTH_ISSUER)
+OAUTH_JWKS_URL = os.environ.get(
+    "OAUTH_JWKS_URL", f"{OAUTH_ISSUER.rstrip('/')}/.well-known/jwks.json"
+)
+MCP_RESOURCE_URL = os.environ.get(
+    "MCP_RESOURCE_URL", "https://mcp.flexreportfinapi.com/mcp"
+)
+
+# PyJWKClient caches fetched keys; create it lazily so import never does network I/O.
+_jwks_client: PyJWKClient | None = None
+
+
+def _jwks() -> PyJWKClient:
+    global _jwks_client
+    if _jwks_client is None:
+        _jwks_client = PyJWKClient(OAUTH_JWKS_URL)
+    return _jwks_client
+
+
+def _decode_rs256(token: str) -> dict:
+    """Validate signature (via JWKS), `aud`, `iss`, `exp`. Raises on any failure."""
+    signing_key = _jwks().get_signing_key_from_jwt(token)
+    return jwt.decode(
+        token,
+        signing_key.key,
+        algorithms=["RS256"],
+        audience=OAUTH_AUDIENCE,
+        issuer=OAUTH_ISSUER,
+    )
+
+
+class FlexReportTokenVerifier(TokenVerifier):
+    """Validate the backend's RS256 OAuth access tokens.
+
+    `lenient` (AUTH_MODE=both): tokens that fail RS256 validation are passed through
+    as opaque — the backend re-validates and 401s anything invalid. This keeps legacy
+    static-JWT (HS256) header users working during the transition without this service
+    ever holding the legacy secret. AUTH_MODE=oauth sets lenient=False (strict).
+    """
+
+    def __init__(self, lenient: bool):
+        self.lenient = lenient
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        try:
+            # JWKS lookup + decode are sync (network on cache-miss) — keep off the loop.
+            claims = await anyio.to_thread.run_sync(_decode_rs256, token)
+        except Exception:
+            if self.lenient:
+                return AccessToken(
+                    token=token,
+                    client_id="legacy",
+                    scopes=[],
+                    expires_at=None,
+                    resource=MCP_RESOURCE_URL,
+                )
+            return None
+        return AccessToken(
+            token=token,
+            client_id=claims.get("client_id", ""),
+            scopes=(claims.get("scope") or "").split(),
+            expires_at=claims.get("exp"),
+            resource=MCP_RESOURCE_URL,
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
-mcp>=1.2.0
+mcp>=1.27.0
 httpx>=0.27.0
+# OAuth Resource-Server token validation (RS256 via the backend JWKS). The [crypto]
+# extra pulls in `cryptography` for RSA signature verification.
+pyjwt[crypto]>=2.8.0

--- a/server.py
+++ b/server.py
@@ -16,11 +16,25 @@ from starlette.responses import PlainTextResponse
 
 from client import MissingAuthError, auth_headers, get_client
 
-# Advertised to every client on connect (MCP `instructions`) — the hardwired
-# auth playbook so any agent self-serves login without guessing.
-INSTRUCTIONS = """\
-FlexReport Finance — live market events and equity research as tools.
+# Auth posture (env). Controls how inbound requests are authenticated:
+#   legacy → no token validation; agent self-serves via get_token/register_user
+#            (today's behavior). Deploying new code is a no-op until you flip this.
+#   both   → OAuth Resource Server: RS256 tokens validated against the backend JWKS,
+#            non-OAuth tokens passed through (legacy static-JWT users keep working),
+#            password tools removed. Transition state.
+#   oauth  → strict: only valid RS256 OAuth tokens accepted. End state.
+AUTH_MODE = os.environ.get("AUTH_MODE", "legacy").lower()
+_OAUTH_ENABLED = AUTH_MODE in ("oauth", "both")
 
+# Mode-aware auth playbook advertised to every client on connect (MCP `instructions`).
+if _OAUTH_ENABLED:
+    _AUTH_BLOCK = """\
+AUTHENTICATE via OAuth — handled by your MCP client (e.g. Claude) in the browser.
+There are NO password/token tools: just call a data tool, and if you are not signed in
+the client runs the sign-in/consent flow for you. NEVER ask the user for a password or a
+token, and do NOT pass `bearer_token` — the client attaches the token automatically."""
+else:
+    _AUTH_BLOCK = """\
 AUTHENTICATE before any data tool. The user needs a FlexReport account + a JWT:
 - Existing user: call get_token(username=<email>, password=<password>) -> access_token.
 - New user (no account): call register_user(email, password); the backend emails a
@@ -29,7 +43,12 @@ AUTHENTICATE before any data tool. The user needs a FlexReport account + a JWT:
 Pass the access_token as the `bearer_token` argument on every data tool
 (list_realtime_events, get_latest_report, generate_report, generate_research_report,
 onboard_symbol). On HTTP 401 the token expired — call
-get_token again and retry. Do NOT ask the user to paste tokens into config files.
+get_token again and retry. Do NOT ask the user to paste tokens into config files."""
+
+INSTRUCTIONS = f"""\
+FlexReport Finance — live market events and equity research as tools.
+
+{_AUTH_BLOCK}
 
 REPORTS — pick the right tool:
 - DEFAULT for "the report / research / analysis / writeup for <ticker>": call
@@ -43,6 +62,27 @@ get_company_snapshot, get_stock_picks, get_task_status. Use list_report_options(
 to discover valid parameter values instead of guessing.
 """
 
+# OAuth Resource-Server wiring (only when AUTH_MODE enables it). The SDK then serves
+# /.well-known/oauth-protected-resource and returns 401 + WWW-Authenticate challenges,
+# pointing clients at the backend Authorization Server (issuer_url).
+_auth_settings = None
+_token_verifier = None
+if _OAUTH_ENABLED:
+    from mcp.server.auth.settings import AuthSettings
+
+    from auth_verifier import (
+        MCP_RESOURCE_URL,
+        OAUTH_ISSUER,
+        FlexReportTokenVerifier,
+    )
+
+    _token_verifier = FlexReportTokenVerifier(lenient=(AUTH_MODE == "both"))
+    _auth_settings = AuthSettings(
+        issuer_url=OAUTH_ISSUER,
+        resource_server_url=MCP_RESOURCE_URL,
+        required_scopes=[],  # backend enforces scope/plan; don't gate at the transport
+    )
+
 mcp = FastMCP(
     "flexreport",
     instructions=INSTRUCTIONS,
@@ -51,10 +91,21 @@ mcp = FastMCP(
     # Behind a load balancer (ALB): make each request self-contained instead of
     # holding a long-lived per-session SSE stream the LB would choke on, and return
     # plain JSON rather than text/event-stream. Stateless mode has no persistent
-    # session, so auth is per-call `bearer_token` (from get_token), not a cache.
+    # session, so auth is per-call (an OAuth bearer, or legacy `bearer_token`), not a cache.
     stateless_http=True,
     json_response=True,
+    auth=_auth_settings,
+    token_verifier=_token_verifier,
 )
+
+
+def _pre_auth_tool(fn):
+    """Register the legacy password/registration tools only in AUTH_MODE=legacy.
+
+    Under OAuth these are dead (transport auth rejects the token-less connection they
+    relied on) and shouldn't be advertised — sign-in moves to the browser flow.
+    """
+    return mcp.tool()(fn) if not _OAUTH_ENABLED else fn
 
 
 def _inbound_request(ctx: Context):
@@ -464,7 +515,7 @@ async def get_stock_picks(
 # Then pass access_token as `bearer_token` on every data tool. Stateless deployment,
 # so there is no server-side session/login cache — the token rides each call.
 
-@mcp.tool()
+@_pre_auth_tool
 async def register_user(ctx: Context, email: str, password: str) -> Any:
     """Register a new FlexReport account (step 1 for new users).
 
@@ -480,7 +531,7 @@ async def register_user(ctx: Context, email: str, password: str) -> Any:
     )
 
 
-@mcp.tool()
+@_pre_auth_tool
 async def confirm_registration(ctx: Context, token: str) -> Any:
     """Confirm a registration with the emailed token (step 2 of the auth flow).
 
@@ -489,7 +540,7 @@ async def confirm_registration(ctx: Context, token: str) -> Any:
     return await _send(ctx, "GET", f"/confirm/{token}", require_auth=False)
 
 
-@mcp.tool()
+@_pre_auth_tool
 async def get_token(ctx: Context, username: str, password: str) -> Any:
     """Exchange credentials for a bearer JWT (OAuth2 password flow). Pre-auth.
 


### PR DESCRIPTION
Make the MCP server a spec-compliant OAuth Resource Server so clients can authenticate via the backend's browser-based auth-code + PKCE flow instead of passing email/password as tool arguments.

- auth_verifier.py: validate the backend's RS256 access tokens via its JWKS (signature + iss + aud + exp). In AUTH_MODE=both, non-OAuth tokens are passed through opaque (legacy static-JWT users keep working; backend stays the final authority); AUTH_MODE=oauth is strict. JWKS fetch URL is decoupled from the issuer claim so it works behind container/internal networking.
- server.py: AUTH_MODE=legacy|both|oauth wires FastMCP auth/token_verifier, which serves /.well-known/oauth-protected-resource and 401 + WWW-Authenticate challenges. Mode-aware instructions; the pre-auth password tools (get_token/register_user/confirm_registration) are registered only in legacy.
- requirements.txt: add pyjwt[crypto]; bump mcp>=1.27.
- Dockerfile: copy auth_verifier.py into the image.
- .env.example: document AUTH_MODE and the OAUTH_* / MCP_RESOURCE_URL vars.

Validated end-to-end in Docker against the backend AS: no-token -> 401, tampered -> 401, valid RS256 -> 200 + authed tool call proxied to the backend.