### PR TITLE
Add get_aftermarket_trades and get_aftermarket_quotes tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ make it available in every directory. See [Auth](#auth) for details.
 | `list_tickers(with_names)` | `GET /list-tickers` or `/list-symbols-with-names` | The covered ticker universe (optionally with company names) |
 | `get_company_snapshot(symbol)` | `GET /get-company-snapshot` | Structured snapshot: thesis, fundamentals, technicals, price targets, ownership, grades |
 | `detect_intraday_outlier_jumps(symbol, zscore_threshold)` | `GET /detect-intraday-outlier-jumps` | Live look at today's 1-min tape; flags minutes whose move is a daily-sigma outlier (synchronous, authed) |
+| `get_aftermarket_trades(symbols, start_datetime, end_datetime)` | `POST /get-aftermarket-trades` | Query **stored** extended-hours trade ticks for symbols over an ET datetime range (defaults to today, authed, 300/min) |
+| `get_aftermarket_quotes(symbols, start_datetime, end_datetime)` | `POST /get-aftermarket-quotes` | Query **stored** extended-hours bid/ask quote ticks for symbols over an ET datetime range (defaults to today, authed, 300/min) |
 | `onboard_symbol(symbol)` | `POST /onboard-symbol` | Request onboarding of an uncovered ticker (async, authed, 5/hour) |
 | `register_user(email, password)` | `POST /auth` | Register for an API key; backend emails a confirmation token (pre-auth, **`AUTH_MODE=legacy` only**) |
 | `confirm_registration(token)` | `GET /confirm/{token}` | Confirm a registration with the emailed token (pre-auth, **`AUTH_MODE=legacy` only**) |

--- a/server.py
+++ b/server.py
@@ -474,6 +474,86 @@ async def detect_intraday_outlier_jumps(
     )
 
 
+async def _query_aftermarket(
+    ctx: Context,
+    path: str,
+    symbols: list[str],
+    start_datetime: Optional[str],
+    end_datetime: Optional[str],
+    bearer_token: Optional[str],
+) -> Any:
+    """Build the AftermarketQuery body and forward it to a stored-data endpoint.
+
+    `start_datetime`/`end_datetime` are only included when supplied so the backend
+    applies its defaults (start/end of today in ET) for whichever bound is omitted.
+    """
+    body: dict[str, Any] = {"symbols": symbols}
+    if start_datetime:
+        body["start_datetime"] = start_datetime
+    if end_datetime:
+        body["end_datetime"] = end_datetime
+    return await _send(ctx, "POST", path, json=body, bearer_token=bearer_token)
+
+
+@mcp.tool()
+async def get_aftermarket_trades(
+    ctx: Context,
+    symbols: list[str],
+    start_datetime: Optional[str] = None,
+    end_datetime: Optional[str] = None,
+    bearer_token: Optional[str] = None,
+) -> Any:
+    """Query STORED aftermarket (extended-hours) TRADE data for symbols over a datetime range.
+
+    Returns the trade ticks the backend has ingested for `symbols`, filtered on
+    `ingested_at` between `start_datetime` and `end_datetime` (inclusive). Use it to
+    pull the recorded extended-hours tape — i.e. read back already-captured aftermarket
+    prints, NOT a live feed. For a live intraday read of the regular session use
+    `detect_intraday_outlier_jumps` instead.
+
+    `start_datetime` and `end_datetime` are ET wall-clock ISO-8601 timestamps
+    (e.g. "2026-06-24T16:00:00"). Both are OPTIONAL: omit them and the backend
+    defaults to the start (00:00:00) and end (23:59:59) of today in ET, so leave
+    them off for "today's aftermarket trades".
+
+    Requires auth: pass `bearer_token` (a JWT from `get_token`); on 401 re-mint and
+    retry. Omit only if the MCP client forwards an Authorization header. Rate-limited
+    to 300/minute per user server-side.
+    """
+    return await _query_aftermarket(
+        ctx, "/get-aftermarket-trades", symbols, start_datetime, end_datetime, bearer_token
+    )
+
+
+@mcp.tool()
+async def get_aftermarket_quotes(
+    ctx: Context,
+    symbols: list[str],
+    start_datetime: Optional[str] = None,
+    end_datetime: Optional[str] = None,
+    bearer_token: Optional[str] = None,
+) -> Any:
+    """Query STORED aftermarket (extended-hours) QUOTE data for symbols over a datetime range.
+
+    Returns the bid/ask quote ticks the backend has ingested for `symbols`, filtered on
+    `ingested_at` between `start_datetime` and `end_datetime` (inclusive). Use it to
+    pull the recorded extended-hours quotes — i.e. read back already-captured aftermarket
+    bid/ask data, NOT a live feed. The trade-print counterpart is `get_aftermarket_trades`.
+
+    `start_datetime` and `end_datetime` are ET wall-clock ISO-8601 timestamps
+    (e.g. "2026-06-24T16:00:00"). Both are OPTIONAL: omit them and the backend
+    defaults to the start (00:00:00) and end (23:59:59) of today in ET, so leave
+    them off for "today's aftermarket quotes".
+
+    Requires auth: pass `bearer_token` (a JWT from `get_token`); on 401 re-mint and
+    retry. Omit only if the MCP client forwards an Authorization header. Rate-limited
+    to 300/minute per user server-side.
+    """
+    return await _query_aftermarket(
+        ctx, "/get-aftermarket-quotes", symbols, start_datetime, end_datetime, bearer_token
+    )
+
+
 @mcp.tool()
 async def onboard_symbol(
     ctx: Context,


### PR DESCRIPTION
Expose the backend's stored extended-hours trade/quote endpoints as MCP tools. Both proxy the AftermarketQuery payload (symbols + optional ET datetime range); omitting the datetimes lets the backend default to today (ET). Shared _query_aftermarket helper mirrors the backend's own _query_aftermarket_table factoring.