### PR TITLE
Fix list_realtime_events docstring to enumerate real event families

### DIFF
--- a/server.py
+++ b/server.py
@@ -193,11 +193,24 @@ async def list_realtime_events(
 ) -> Any:
     """Pull live earnings/market events from the backend's Redis-backed cache (12h TTL).
 
-    `event_type` defaults to "eps_update". Other values include: eps_release,
-    8k_release, company_update, biggest_mover, earnings_transcript_update,
-    analyst_rating_update, news_evolution, earnings_themes, llm_basket_update,
-    strategy_update. Call `list_options("event_types")` for the
-    authoritative, current set — do not guess.
+    Event types are grouped into FAMILIES of related events. `event_type` defaults
+    to "eps_update", but that is only one slice of the EARNINGS family — a question
+    about "earnings events" usually spans several of these:
+      - eps_update: intraday earnings tracker (beat/miss summary + news sources)
+      - eps_release: results release detected on announcement day
+      - financials_release: new 10-Q — fully updated company snapshot + updated PDF report
+      - transcript_update: new earnings-call transcript analyzed (thesis deltas + guidance outlook)
+      - 8k_release: earnings 8-K analysis (as-reported financials, takeaways, SEC link)
+      - earnings_themes: cross-company themes for the current earnings season
+
+    Other families: news (news_evolution, company_update), market movement
+    (biggest_gainer / biggest_mover / biggest_loser), institutional ownership
+    (individual_13f_filer_change, 13f_significant_position_change), analyst
+    activity (realtime_ratings_update, financial_estimate_update), strategy
+    (strategy_update, llm_basket_update), predictions
+    (stock_return_prediction_update). Call `list_options("event_types")` for the
+    authoritative current set with per-event descriptions — do not guess beyond
+    the values listed here.
 
     Optionally narrow results by `tickers`, `sector`, `industry`, or `market_cap`
     (e.g. market_cap=["Large-cap","Mega-cap"]). Returns a list of event objects,


### PR DESCRIPTION
The old docstring listed event names that don't exist on the backend (earnings_transcript_update, analyst_rating_update) and never mentioned that events are grouped into families, so the MCP agent had no way to know a question about "earnings events" spans eps_update, eps_release, financials_release, transcript_update, 8k_release, and earnings_themes.

Rewrite it to lead with the earnings family and enumerate the other families (news, market movement, institutional ownership, analyst activity, strategy, predictions), while still pointing at list_options("event_types") as the authoritative source.