### PR TITLE
Require an explicit event_type on list_realtime_events

### DIFF
--- a/server.py
+++ b/server.py
@@ -157,7 +157,7 @@ async def _send(
 @mcp.tool(annotations=ToolAnnotations(title="List Real-Time Market Events", readOnlyHint=True))
 async def list_realtime_events(
     ctx: Context,
-    event_type: str = "eps_update",
+    event_type: str,
     tickers: Optional[list[str]] = None,
     sector: Optional[list[str]] = None,
     industry: Optional[list[str]] = None,
@@ -168,8 +168,10 @@ async def list_realtime_events(
     On ANY real-time/events request, call `list_options("event_types")` FIRST —
     it returns every event type with its family, description, and the
     related_events that fire around the same situation. Work from that
-    catalogue, never a remembered list of types. `event_type` defaults to
-    "eps_update", which is only one slice of the earnings family.
+    catalogue, never a remembered list of types. `event_type` is REQUIRED and
+    has no default on purpose: the type is the whole question, and a default
+    would answer a different one (eps_update is one slice of the earnings
+    family, not the family).
 
     Then CONNECT THE DOTS: fetch the type asked about and follow the situation
     across its related_events with follow-up calls narrowed by `tickers=[...]`


### PR DESCRIPTION
The default of "eps_update" quietly answered a different question than the one asked: the type IS the question, and a default meant a caller who never consulted list_options("event_types") still got a plausible-looking result from one slice of the earnings family.

Drop the default so the schema marks event_type required — clients pre-fill from the schema, so this is what actually forces the catalogue lookup.